### PR TITLE
[mesa] disable avx support - JB#18552

### DIFF
--- a/mesa/src/gallium/auxiliary/util/u_cpu_detect.c
+++ b/mesa/src/gallium/auxiliary/util/u_cpu_detect.c
@@ -281,12 +281,21 @@ util_cpu_detect(void)
          util_cpu_caps.has_sse2   = (regs2[3] >> 26) & 1; /* 0x4000000 */
          util_cpu_caps.has_sse3   = (regs2[2] >>  0) & 1; /* 0x0000001 */
          util_cpu_caps.has_ssse3  = (regs2[2] >>  9) & 1; /* 0x0000020 */
+#if 0
          util_cpu_caps.has_sse4_1 = (regs2[2] >> 19) & 1;
          util_cpu_caps.has_sse4_2 = (regs2[2] >> 20) & 1;
          util_cpu_caps.has_popcnt = (regs2[2] >> 23) & 1;
          util_cpu_caps.has_avx    = (regs2[2] >> 28) & 1;
          util_cpu_caps.has_f16c   = (regs2[2] >> 29) & 1;
          util_cpu_caps.has_mmx2   = util_cpu_caps.has_sse; /* SSE cpus supports mmxext too */
+#else
+         util_cpu_caps.has_sse4_1 = 0;
+         util_cpu_caps.has_sse4_2 = 0;
+         util_cpu_caps.has_popcnt = 0;
+         util_cpu_caps.has_avx    = 0;
+         util_cpu_caps.has_f16c   = 0;
+         util_cpu_caps.has_mmx2   = 0;
+#endif
 
          cacheline = ((regs2[1] >> 8) & 0xFF) * 8;
          if (cacheline > 0)


### PR DESCRIPTION
AVX/SSE4 cpuid information can leak through to the system in some
circumstances and mesa/llvm tries to use it for llvmpipe and
VirtualBox will SIGILL as it doesn't support it.

Signed-off-by: Juha Kallioinen juha.kallioinen@jolla.com
