### PR TITLE
[mesa] Include sys/stat.h explicitly. Fixes MER#1346

### DIFF
--- a/mesa/src/gallium/targets/egl-static/egl.c
+++ b/mesa/src/gallium/targets/egl-static/egl.c
@@ -32,6 +32,7 @@
 #ifdef HAVE_LIBUDEV
 #include <stdio.h> /* for sscanf */
 #include <libudev.h>
+#include <sys/stat.h>
 #endif
 
 #define DRIVER_MAP_GALLIUM_ONLY


### PR DESCRIPTION
Mesa relies on libudev.h for inclusion of sys/stat.h which
is not true for new systemd.
Fixed file: src/gallium/targets/egl-static/egl.c.

Signed-off-by: Igor Zhbanov igor.zhbanov@jolla.com
